### PR TITLE
Port ghc-events-analyze to the latest version of dependencies

### DIFF
--- a/ghc-events-analyze.cabal
+++ b/ghc-events-analyze.cabal
@@ -49,7 +49,7 @@ executable ghc-events-analyze
 
   build-depends:       base                 >= 4.5  && < 4.8,
                        ghc-events           >= 0.4  && < 0.5,
-                       optparse-applicative >= 0.7  && < 0.10,
+                       optparse-applicative >= 0.11 && < 0.12,
                        diagrams-lib         >= 1.2  && < 1.3,
                        diagrams-svg         >= 1.1  && < 1.3,
                        SVGFonts             >= 1.4  && < 1.5,

--- a/src/GHC/RTS/Events/Analyze/Options.hs
+++ b/src/GHC/RTS/Events/Analyze/Options.hs
@@ -33,7 +33,7 @@ parserOptions =
     <*> switch     ( long "totals"
                   <> help "Generate totals report"
                    )
-    <*> option     ( long "buckets"
+    <*> option auto( long "buckets"
                   <> short 'b'
                   <> metavar "INT"
                   <> help "Use INT buckets for quantization."


### PR DESCRIPTION
These commits allow to build `ghc-events-analyze` in the latest environment.
