### PR TITLE
Fix a bug where threads were recorded as starting before windows

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,8 @@
-2014-09-23  Will Sewell  <will@pusher.com>
+2015-09-29 Will Sewell <will@pusher.com>
+
+  * Version 0.2.3 fixes issue with thread creation before window start
+
+2015-09-23  Will Sewell  <will@pusher.com>
 
   * Version 0.2.2 adds support for GHC 7.10
 

--- a/ghc-events-analyze.cabal
+++ b/ghc-events-analyze.cabal
@@ -1,5 +1,5 @@
 name:                ghc-events-analyze
-version:             0.2.2
+version:             0.2.3
 synopsis:            Analyze and visualize event logs
 description:         ghc-events-analyze is a simple Haskell profiling tool that
                      uses GHC's eventlog system. It helps with some profiling

--- a/src/GHC/RTS/Events/Analyze/Types.hs
+++ b/src/GHC/RTS/Events/Analyze/Types.hs
@@ -9,7 +9,9 @@ module GHC.RTS.Events.Analyze.Types (
   , startup
   , shutdown
   , numThreads
+  , threadIds
   , inWindow
+  , pendingTids
   , Quantized(..)
   , GroupId
   , showEventId
@@ -108,6 +110,10 @@ data EventAnalysis = EventAnalysis {
     -- | Timestamp of the Shutdown event
   , _shutdown :: !(Maybe Timestamp)
   , _inWindow :: Bool
+
+    -- | This will accumulate threads which were started before a window start.
+    -- Their creation will be recorded once the window starts.
+  , _pendingTids :: [ThreadId]
   }
   deriving Show
 
@@ -118,6 +124,9 @@ threadInfo tid = _threadInfo . at tid
 
 numThreads :: EventAnalysis -> Int
 numThreads analysis = Map.size (analysis ^. _threadInfo)
+
+threadIds :: EventAnalysis -> [ThreadId]
+threadIds analysis = Map.keys (analysis ^. _threadInfo)
 
 -- | Quantization splits the total time up into @n@ buckets. We record for each
 -- event and each bucket what percentage of that bucket the event used. A


### PR DESCRIPTION
This lead to negative time differences in the `bucket` function.
Fixed by only recording thread creations/finishes at window creations/finishes.