### PR TITLE
Fix tracking of threads across windows

### DIFF
--- a/src/GHC/RTS/Events/Analyze/Reports/Totals.hs
+++ b/src/GHC/RTS/Events/Analyze/Reports/Totals.hs
@@ -55,7 +55,7 @@ createReport analysis@EventAnalysis{..} = concatMap go
 
     reportLine :: Maybe Title -> (EventId, Timestamp) -> ReportLine
     reportLine title (eid, total) = ReportLineData {
-        lineHeader   = showTitle (showEventId __threadInfo eid) title
+        lineHeader   = showTitle (showEventId _windowThreadInfo eid) title
       , lineEventIds = [eid]
       , lineTotal    = total
       }

--- a/src/GHC/RTS/Events/Analyze/Types.hs
+++ b/src/GHC/RTS/Events/Analyze/Types.hs
@@ -2,16 +2,19 @@
 module GHC.RTS.Events.Analyze.Types (
     EventId(..)
   , Options(..)
+  , AnalysisState(..)
+  , runningThreads
+  , windowAnalyses
   , EventAnalysis(..)
   , events
-  , threadInfo
+  , windowThreadInfo
   , openEvents
   , startup
   , shutdown
-  , numThreads
-  , threadIds
   , inWindow
-  , pendingTids
+  , ThreadInfo
+  , RunningThreads
+  , threadIds
   , Quantized(..)
   , GroupId
   , showEventId
@@ -19,7 +22,7 @@ module GHC.RTS.Events.Analyze.Types (
   , isThreadEvent
   ) where
 
-import Control.Lens (Lens', makeLenses, at, (^.))
+import Control.Lens (makeLenses)
 import Data.Map (Map)
 import GHC.RTS.Events (Timestamp, ThreadId)
 import qualified Data.Map as Map
@@ -64,9 +67,24 @@ data Options = Options {
   }
   deriving Show
 
+-- | Map of currently running threads to their labels
+type RunningThreads = Map ThreadId String
+
+threadIds :: RunningThreads -> [ThreadId]
+threadIds = Map.keys
+
+-- | Information about each thread to be stored per window
+--
+-- When was the thread created, when was it destroyed, and what is the
+-- thread label (as indicated by ThreadLabel events)
+--
+-- The default label for each thread is the thread ID
+type ThreadInfo = Map ThreadId (Timestamp, Timestamp, String)
+
+-- | Analysis of a window (or the whole program run if there aren't any).
 -- The fields that we use as "accumulators" in `analyze` are strict so that we
 -- don't build up chains of EventAnalysis objects when we update it as we
--- process the eventlog
+-- process the eventlog.
 data EventAnalysis = EventAnalysis {
     -- | Start and stop timestamps
     --
@@ -74,13 +92,8 @@ data EventAnalysis = EventAnalysis {
     -- be equal to the @start@ timestamp
     _events :: ![(EventId, Timestamp, Timestamp)]
 
-    -- | Information about each thread
-    --
-    -- When was the thread created, when was it destroyed, and what is the
-    -- thread label (as indicated by ThreadLabel events)
-    --
-    -- The default label for each thread is the thread ID
-  , __threadInfo :: !(Map ThreadId (Timestamp, Timestamp, String))
+    -- | Window-specific thread info
+  , _windowThreadInfo :: ThreadInfo
 
     -- | Event with a start but with a missing end.
     --
@@ -110,23 +123,19 @@ data EventAnalysis = EventAnalysis {
     -- | Timestamp of the Shutdown event
   , _shutdown :: !(Maybe Timestamp)
   , _inWindow :: Bool
-
-    -- | This will accumulate threads which were started before a window start.
-    -- Their creation will be recorded once the window starts.
-  , _pendingTids :: [ThreadId]
   }
   deriving Show
 
 $(makeLenses ''EventAnalysis)
 
-threadInfo :: ThreadId -> Lens' EventAnalysis (Maybe (Timestamp, Timestamp, String))
-threadInfo tid = _threadInfo . at tid
+-- | State while running an analysis. Keeps track of currently running threads,
+-- and appends an 'EventAnalysis' per window.
+data AnalysisState = AnalysisState {
+    _runningThreads :: RunningThreads
+  , _windowAnalyses :: [EventAnalysis]
+}
 
-numThreads :: EventAnalysis -> Int
-numThreads analysis = Map.size (analysis ^. _threadInfo)
-
-threadIds :: EventAnalysis -> [ThreadId]
-threadIds analysis = Map.keys (analysis ^. _threadInfo)
+$(makeLenses ''AnalysisState)
 
 -- | Quantization splits the total time up into @n@ buckets. We record for each
 -- event and each bucket what percentage of that bucket the event used. A


### PR DESCRIPTION
Finally fixed https://github.com/well-typed/ghc-events-analyze/issues/17. Went for the first solution I came up with in that issue.

The currently running threads are now stored in `RunningThreads` which is global state across windows in an analysis. When a window is entered, all running thrads are reported as started. and when a window is stopped, all running threads are reported as stopped for that window.

This does not support tracking of events that were started before a window, but stopped after a window is started. I'm not sure how valuable this would be. 

