### PR TITLE
Support GHC-8.6 and GHC-8.8

### DIFF
--- a/ghc-events-analyze.cabal
+++ b/ghc-events-analyze.cabal
@@ -51,7 +51,7 @@ executable ghc-events-analyze
                        GHC.RTS.Events.Analyze.Reports.Timed
                        GHC.RTS.Events.Analyze.Reports.Timed.SVG
 
-  build-depends:       base                 >= 4.8   && < 4.12,
+  build-depends:       base                 >= 4.8   && < 4.13,
                        blaze-svg            >= 0.3   && < 0.4,
                        bytestring           >= 0.10  && < 0.11,
                        containers           >= 0.5   && < 0.7,

--- a/ghc-events-analyze.cabal
+++ b/ghc-events-analyze.cabal
@@ -51,7 +51,7 @@ executable ghc-events-analyze
                        GHC.RTS.Events.Analyze.Reports.Timed
                        GHC.RTS.Events.Analyze.Reports.Timed.SVG
 
-  build-depends:       base                 >= 4.8   && < 4.13,
+  build-depends:       base                 >= 4.8   && < 4.14,
                        blaze-svg            >= 0.3   && < 0.4,
                        bytestring           >= 0.10  && < 0.11,
                        containers           >= 0.5   && < 0.7,
@@ -59,15 +59,15 @@ executable ghc-events-analyze
                        diagrams-svg         >= 1.1   && < 1.5,
                        filepath             >= 1.3   && < 1.5,
                        ghc-events           >= 0.6,
-                       hashable             >= 1.2   && < 1.3,
-                       lens                 >= 3.10  && < 4.18,
+                       hashable             >= 1.2   && < 1.4,
+                       lens                 >= 3.10  && < 4.19,
                        mtl                  >= 2.2.1 && < 2.3,
-                       optparse-applicative >= 0.11  && < 0.15,
+                       optparse-applicative >= 0.11  && < 0.16,
                        parsec               >= 3.1   && < 3.2,
                        regex-base           >= 0.93  && < 0.94,
                        regex-pcre-builtin   >= 0.94  && < 0.95,
                        SVGFonts             >= 1.5   && < 1.8,
-                       th-lift              >= 0.6   && < 0.8,
+                       th-lift              >= 0.6   && < 0.9,
                        transformers         >= 0.3   && < 0.6,
                        unordered-containers >= 0.2   && < 0.3,
                        -- No version: whatever is bundled with ghc

--- a/src/GHC/RTS/Events/Analyze.hs
+++ b/src/GHC/RTS/Events/Analyze.hs
@@ -2,6 +2,7 @@
 module Main where
 
 import Control.Monad (when, forM_)
+import qualified Data.List.NonEmpty as NonEmpty
 import Data.Maybe (isNothing)
 import System.FilePath (replaceExtension, takeFileName)
 import Text.Parsec.String (parseFromFile)
@@ -44,7 +45,7 @@ main = do
           | isNothing optionsWindowEvent = filename
           | otherwise                    = show i ++ "." ++ filename
 
-    forM_ (zip [0..] analyses) $ \ (i,analysis) -> do
+    forM_ (zip [0..] (NonEmpty.toList analyses)) $ \ (i,analysis) -> do
 
       let quantized = quantize optionsNumBuckets analysis
           totals    = Totals.createReport analysis totalsScript

--- a/src/GHC/RTS/Events/Analyze/Types.hs
+++ b/src/GHC/RTS/Events/Analyze/Types.hs
@@ -42,6 +42,7 @@ import Data.Char
 import Data.Hashable
 import Data.HashMap.Strict (HashMap)
 import Data.IntMap.Strict (IntMap)
+import Data.List.NonEmpty (NonEmpty)
 import GHC.Generics
 import GHC.RTS.Events (Timestamp, ThreadId)
 import Text.Regex.PCRE
@@ -220,7 +221,7 @@ mkThreadFilter analysis regex =
 -- and appends an 'EventAnalysis' per window.
 data AnalysisState = AnalysisState {
     _runningThreads :: RunningThreads
-  , _windowAnalyses :: [EventAnalysis]
+  , _windowAnalyses :: NonEmpty EventAnalysis
 }
 
 $(makeLenses ''AnalysisState)


### PR DESCRIPTION
A partial pattern match in `cur` required `MonadFail`, so I refactored `AnalysisState` to contain a non-empty list of `EventAnalysis`.

Support for GHC-8.8 isn't quite complete yet:

  * regex-base needs an update
  * diagrams-svg needs to allow some new dependency versions