### PR TITLE
Compatibility updates

### DIFF
--- a/ghc-events-analyze.cabal
+++ b/ghc-events-analyze.cabal
@@ -51,7 +51,7 @@ executable ghc-events-analyze
                        GHC.RTS.Events.Analyze.Reports.Timed
                        GHC.RTS.Events.Analyze.Reports.Timed.SVG
 
-  build-depends:       base                 >= 4.8   && < 4.14,
+  build-depends:       base                 >= 4.9   && < 4.14,
                        blaze-svg            >= 0.3   && < 0.4,
                        bytestring           >= 0.10  && < 0.11,
                        containers           >= 0.5   && < 0.7,
@@ -64,8 +64,8 @@ executable ghc-events-analyze
                        mtl                  >= 2.2.1 && < 2.3,
                        optparse-applicative >= 0.11  && < 0.16,
                        parsec               >= 3.1   && < 3.2,
-                       regex-base           >= 0.93  && < 0.94,
-                       regex-pcre-builtin   >= 0.94  && < 0.95,
+                       regex-base           >= 0.93  && < 0.95,
+                       regex-pcre-builtin   >= 0.94  && < 0.96,
                        SVGFonts             >= 1.5   && < 1.8,
                        th-lift              >= 0.6   && < 0.9,
                        transformers         >= 0.3   && < 0.6,

--- a/src/GHC/RTS/Events/Analyze.hs
+++ b/src/GHC/RTS/Events/Analyze.hs
@@ -7,10 +7,6 @@ import Data.Maybe (isNothing)
 import System.FilePath (replaceExtension, takeFileName)
 import Text.Parsec.String (parseFromFile)
 
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative ((<$>))
-#endif
-
 import GHC.RTS.Events.Analyze.Analysis
 import GHC.RTS.Events.Analyze.Options
 import qualified GHC.RTS.Events.Analyze.Reports.Totals    as Totals

--- a/src/GHC/RTS/Events/Analyze/Analysis.hs
+++ b/src/GHC/RTS/Events/Analyze/Analysis.hs
@@ -25,10 +25,6 @@ import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.List.NonEmpty as NonEmpty
 import GHC.RTS.Events hiding (events)
 
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative ((<$>))
-#endif
-
 import GHC.RTS.Events.Analyze.Utils
 import GHC.RTS.Events.Analyze.StrictState (State, execState, put, get, runState)
 import GHC.RTS.Events.Analyze.Types

--- a/src/GHC/RTS/Events/Analyze/Options.hs
+++ b/src/GHC/RTS/Events/Analyze/Options.hs
@@ -7,10 +7,6 @@ module GHC.RTS.Events.Analyze.Options (
 import Data.Foldable (asum)
 import Options.Applicative
 
-#if !MIN_VERSION_base(4,8,0)
-import Data.Monoid (mconcat)
-#endif
-
 import GHC.RTS.Events.Analyze.Types
 import GHC.RTS.Events.Analyze.Script
 import GHC.RTS.Events.Analyze.Script.Standard

--- a/src/GHC/RTS/Events/Analyze/Reports/Timed/SVG.hs
+++ b/src/GHC/RTS/Events/Analyze/Reports/Timed/SVG.hs
@@ -17,10 +17,6 @@ import qualified Graphics.SVGFonts.Text     as F
 import qualified Graphics.SVGFonts.ReadFont as F
 import qualified Diagrams.TwoD.Text as TT
 
-#if !MIN_VERSION_base(4,8,0)
-import Data.Monoid (mempty, mconcat)
-#endif
-
 import GHC.RTS.Events.Analyze.Types
 import GHC.RTS.Events.Analyze.Reports.Timed hiding (writeReport)
 

--- a/src/GHC/RTS/Events/Analyze/StrictState.hs
+++ b/src/GHC/RTS/Events/Analyze/StrictState.hs
@@ -22,10 +22,6 @@ import qualified Control.Monad.State.Strict as St
 import Control.Monad.Trans.Class (MonadTrans)
 import Control.Monad.Identity (Identity(..))
 
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative
-#endif
-
 {-------------------------------------------------------------------------------
   Transformer
 -------------------------------------------------------------------------------}


### PR DESCRIPTION
* Fix build with GHC-8.8:
  - Bump bounds on regex-base and regex-pcre-builtin
  - Require MonadFail in parseScriptString

* Prevent failing build with GHC-7.10 by raising lower bound on base

* Remove redundant CPP