### PR TITLE
Use signed parser for EventId

### DIFF
--- a/src/GHC/RTS/Events/Analyze/Types.hs
+++ b/src/GHC/RTS/Events/Analyze/Types.hs
@@ -106,7 +106,7 @@ isThreadEvent _                 = Nothing
 -- If the event name starts with a digit, regard it as a 'EventSubscript'.
 parseUserEvent :: Text -> EventId
 parseUserEvent s =
-    case TR.decimal s of
+    case TR.signed TR.decimal s of
       Left _ -> EventUser s 0
       Right (eid, cs) -> EventUser (T.dropWhile isSpace cs) eid
 


### PR DESCRIPTION
The type itself is signed, but the parser balks when using Ints from e.g. Hashable.